### PR TITLE
Build ARM images

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -10,6 +10,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
         
@@ -24,6 +27,7 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         push: true
+        platforms: linux/amd64,linux/arm64
         context: .
         file: ./Dockerfile
         tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,12 @@ RUN \
       apache2 \
       binutils-dev \
       binutils-aarch64-linux-gnu \
+      binutils-x86-64-linux-gnu \
       build-essential \
       dosfstools \
       figlet \
       gcc-aarch64-linux-gnu \
+      gcc-x86-64-linux-gnu \
       genisoimage \
       git \
       isolinux \
@@ -22,8 +24,6 @@ RUN \
       libslirp-dev \
       python3-pip \
       python3-setuptools \
-      syslinux \
-      syslinux-common \
       toilet
 
 RUN pip3 install ansible==${ANSIBLE_VERSION}


### PR DESCRIPTION
This builds images for ARM to speed up development on native ARM hosts such as computers with Apple Silicon.

Also drop syslinux packages as they are unavailable on architectures other than x86 and are not used in the build process.